### PR TITLE
feat: HTTP client disconnects handling

### DIFF
--- a/latch_asgi/server.py
+++ b/latch_asgi/server.py
@@ -40,6 +40,7 @@ from .context import http, websocket
 from .datadog_propagator import DDTraceContextTextMapPropagator
 from .framework.common import otel_header_whitelist
 from .framework.http import (
+    HTTPConnectionClosedError,
     HTTPErrorResponse,
     HTTPInternalServerError,
     current_http_request_span,
@@ -303,6 +304,9 @@ class LatchASGIServer:
                         await send_auto(send, HTTPStatus.OK, res)
             except HTTPErrorResponse:
                 raise
+            except HTTPConnectionClosedError as e:
+                s.record_exception(e)
+                return
             except Exception as e:
                 # todo(maximsmol): better error message
                 raise HTTPInternalServerError("Internal error") from e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "latch-asgi"
-version = "1.1.1"
+version = "1.1.2"
 description = "ASGI python server"
 authors = [{ name = "Max Smolin", email = "max@latch.bio" }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -272,7 +272,7 @@ wheels = [
 
 [[package]]
 name = "latch-asgi"
-version = "1.1.0"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "hypercorn", extra = ["uvloop"] },


### PR DESCRIPTION
Handle HTTP client disconnects during request body, set exception on span and return instead of wrapping them as internal server errors. Bump package version to 1.1.2.